### PR TITLE
Reports and xml changes

### DIFF
--- a/ctq_customs/__manifest__.py
+++ b/ctq_customs/__manifest__.py
@@ -19,6 +19,7 @@
         'l10n_mx_reports',
     ],
     'data': [
+        'report/purchase_report_templates.xml',
         'report/report_invoice.xml',
         'report/sale_report_templates.xml',
         'data/res_groups_data.xml',

--- a/ctq_customs/models/account_move.py
+++ b/ctq_customs/models/account_move.py
@@ -81,10 +81,14 @@ class AccountMove(models.Model):
                     if landed_cost:
                         line.name += " [Fecha documento aduanero: {}]".format(landed_cost.date)
                 if lots:
-                    string = " [Número(s) de Lote: "#.format(lot['lot_name'])
-                    for lot in lots:
+                    count = line.quantity
+                    string = " [Número(s) de Lote: "
+                    while lots and count > 0:
+                        count -= 1
+                        lot = lots[0]
                         if lot['product_name'] == line.product_id.display_name:
-                            string += str(lot['lot_name']) + ", "#" [Número de Lote: {}]".format(lot['lot_name'])
+                            string += str(lot['lot_name']) + ", "
+                            lots.remove(lot)
                     if string != " [Número(s) de Lote: ":
                         string = string[:-2] + "]"
                         if landed_cost:

--- a/ctq_customs/report/purchase_report_templates.xml
+++ b/ctq_customs/report/purchase_report_templates.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-<template id="report_saleorder_document_ctq" inherit_id="sale.report_saleorder_document">
+<template id="report_purchaseorder_document_ctq" inherit_id="purchase.report_purchaseorder_document">
     <xpath expr="//th[@name='th_description']" position="before">
         <th name="th_line_count" class="text-left">#</th>
     </xpath>
-    <xpath expr="//t[@t-foreach='doc.order_line']" position="before">
-        <t t-set="line_count" t-value="1"/>
+    <xpath expr="//t[@t-foreach='o.order_line']" position="before">
+        <t t-set="line_count" t-value="0"/>
     </xpath>
-    <xpath expr="//t[@t-foreach='doc.order_line']" position="inside">
+    <xpath expr="//td[@id='product']" position="before">
         <t t-if="line.display_type not in ('line_section', 'line_note')">
             <t t-set="line_count" t-value="line_count + 1"/>
         </t>
-    </xpath>
-    <xpath expr="//td[@name='td_name']" position="before">
         <td name="td_line_count"><span t-esc="line_count"/></td>
     </xpath>
 </template>


### PR DESCRIPTION
1. Fixed a bug in reports #'s column where it counted the notes and sections as lines, therefore the counter increased when no product lines where passed by
2. Fixed a bug where, if you had the same product in multiple lines of the invoice, the lot numbers got duplicated. Now the lot numbers distribute through all the lines of the same product in the invoice